### PR TITLE
[DNS recovery]: only send if sendQueue is small

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Available options:
  * `prefix`: Prefix all stats with this value (default `""`).
  * `socket_timeout`: Auto-closes the socket after this long without activity
    (default 1000 ms; 0 disables this).
+ * `highWaterMark`: The maximum number of udp messges buffered in
+    case DNS lookup takes too long. default to 100
 
 ### Counting stuff
 

--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -7,6 +7,7 @@ function ephemeralSocket(options) {
     this.options.port = this.options.port || 8125;
     this.options.debug = this.options.debug || false;
     this.options.socket_timeout = this.options.socket_timeout || 1000;
+    this.options.highWaterMark = this.options.highWaterMark || 100;
 
     // Set up re-usable socket
     this._socket = undefined; // Store the socket here
@@ -77,7 +78,12 @@ ephemeralSocket.prototype.send = function (data) {
         console.warn(message.toString());
     }
 
-    this._socket.send(message, 0, message.length, this.options.port, this.options.host);
+    if (!this._socket._sendQueue ||
+        this._socket._sendQueue.length < this.options.highWaterMark
+    ) {
+        this._socket.send(message, 0, message.length,
+            this.options.port, this.options.host);
+    }
 };
 
 module.exports = ephemeralSocket;


### PR DESCRIPTION
First patch to dns-recovery branch.

This gaurds against a known unbounded queue in node core.

cc @Matt-Esch @mranney @jcorbin
