### PR TITLE
[DNS recovery]: Remove timeout feature and replace with unref().

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -1,5 +1,4 @@
 var setTimeout = require('timers').setTimeout;
-var clearTimeout = require('timers').clearTimeout;
 var Buffer = require('buffer').Buffer;
 var console = require('console');
 var dgram = require('dgram');
@@ -10,36 +9,11 @@ function ephemeralSocket(options) {
     this.options.host = this.options.host || 'localhost';
     this.options.port = this.options.port || 8125;
     this.options.debug = this.options.debug || false;
-    this.options.socket_timeout = this.options.socket_timeout || 1000;
     this.options.highWaterMark = this.options.highWaterMark || 100;
 
     // Set up re-usable socket
     this._socket = undefined; // Store the socket here
-    this._socket_used = false; // Flag if it has been used
-    this._socket_timer = undefined; // Reference to check-timer
 }
-
-/*
- * Check if the socket has been used in the previous socket_timeout-interval.
- * If it has, we leave it open and try again later. If it hasn't, close it.
- */
-ephemeralSocket.prototype._socket_timeout = function () {
-    // Is it already closed? -- then stop here
-    if (!this._socket) {
-        return;
-    }
-
-    // Has been used? -- reset use-flag and wait some more
-    if (this._socket_used) {
-        this._socket_used = false;
-        this._socket_timer = setTimeout(this._socket_timeout.bind(this), this.options.socket_timeout);
-        return;
-    }
-
-    // Not used? -- close the socket
-    this.close();
-};
-
 
 /*
  * Close the socket, if in use and cancel the interval-check, if running.
@@ -48,9 +22,6 @@ ephemeralSocket.prototype.close = function () {
     if (!this._socket) {
         return;
     }
-
-    // Cancel the running timer
-    clearTimeout(this._socket_timer);
 
     // Wait a tick or two, so any remaining stats can be sent.
     var that = this;
@@ -67,13 +38,8 @@ ephemeralSocket.prototype.send = function (data) {
     // Create socket if it isn't there
     if (!this._socket) {
         this._socket = dgram.createSocket('udp4');
-
-        // Start timer, if we have a positive timeout
-        if (this.options.socket_timeout > 0) {
-            this._socket_timer = setTimeout(this._socket_timeout.bind(this), this.options.socket_timeout);
-        }
+        this._socket.unref();
     }
-    this._socket_used = true;
 
     // Create message
     var message = new Buffer(data);

--- a/test/socket.js
+++ b/test/socket.js
@@ -91,7 +91,7 @@ test('can send multiple packets', function t(assert) {
     });
 });
 
-test('socket will close and timeout', function t(assert) {
+test('socket will unref', function t(assert) {
     var server = UDPServer({ port: PORT }, function onBound() {
         var sock = new EphemeralSocket({
             host: 'localhost',
@@ -105,12 +105,6 @@ test('socket will close and timeout', function t(assert) {
         function onMessage(msg) {
             var str = String(msg);
             assert.equal(str, 'hello');
-
-            setTimeout(expectClosed, 50);
-        }
-
-        function expectClosed() {
-            assert.equal(sock._socket, undefined);
 
             server.close();
             assert.end();


### PR DESCRIPTION
The EphemeralSocket had a timeout feature build into it
   so that the statsd client doesn't keep a CLI program open.

This was implemented in a complicated way with timers, I've
   removed that complexity and replaced it with an unref() call.

cc @sh1mmer @kriskowal
