### PR TITLE
[DNS recovery]: handle errors on the socket

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -16,7 +16,7 @@ function ephemeralSocket(options) {
     self.options.highWaterMark = self.options.highWaterMark || 100;
 
     // Set up re-usable socket
-    self._socket = undefined; // Store the socket here
+    self._socket = null; // Store the socket here
     self._queue = PacketQueue(onFlush, queueOptions);
 
     // flush the packet queue
@@ -51,10 +51,7 @@ ephemeralSocket.prototype.send = function (data) {
  */
 ephemeralSocket.prototype._writeToSocket = function (data) {
     // Create socket if it isn't there
-    if (!this._socket) {
-        this._socket = dgram.createSocket('udp4');
-        this._socket.unref();
-    }
+    allocSocket(this);
 
     // Create message
     var message = new Buffer(data);
@@ -72,3 +69,20 @@ ephemeralSocket.prototype._writeToSocket = function (data) {
 };
 
 module.exports = ephemeralSocket;
+
+function allocSocket(self) {
+    if (self._socket) {
+        return;
+    }
+
+    self._socket = dgram.createSocket('udp4');
+    self._socket.unref();
+
+    self._socket.once('error', onError);
+
+    // When we error we should just close and de-allocate.
+    function onError(err) {
+        self._socket.close();
+        self._socket = null;
+    }
+}

--- a/test/socket.js
+++ b/test/socket.js
@@ -116,6 +116,22 @@ test('socket will unref', function t(assert) {
     });
 });
 
+test('writing to a bad host does not blow up', function t(assert) {
+    var sock = new EphemeralSocket({
+        host: 'lol.example.com',
+        port: PORT,
+        socket_timeout: 0
+    });
+
+    sock.send('hello');
+
+    setTimeout(function () {
+        assert.equal(sock._socket, null);
+        assert.end();
+    }, 50);
+});
+
+
 function UDPServer(opts, onBound) {
     opts = opts || {};
     var port = opts.port || PORT;


### PR DESCRIPTION
This handles errors on the UDP sockets which previously
    went to uncaught. The only real thing to do here
    is to de-allocate the socket.

cc @kriskowal @sh1mmer
