### PR TITLE
[DNS recovery]: support a seed list

### DIFF
--- a/lib/dns-resolver.js
+++ b/lib/dns-resolver.js
@@ -11,6 +11,7 @@ var Backoff = require('./backoff.js');
             retries?: Number,
             factor?: Number
         },
+        seedList: Array<ip: String>,
 
         onresolved: () => void | null
     }
@@ -28,7 +29,7 @@ function DNSResolver(hostname, opts) {
     var backoffSettings = opts.backoffSettings || {};
 
     this._hostname = hostname;
-    this._ipAddresses = null;
+    this._ipAddresses = opts.seedList || null;
 
     this._dns = opts.dns || globalDns;
     this._backoffSettings = backoffSettings;

--- a/test/resolve-dns.js
+++ b/test/resolve-dns.js
@@ -127,3 +127,18 @@ test('DNS resolver will give up', function t(assert) {
         assert.end();
     }
 })
+
+test('DNS resolver defaults to seedList', function t(assert) {
+    var resolver = new DNSResolver(FAKE_HOST, {
+        backoffSettings: {
+            retries: Infinity
+        },
+        seedList: ['0.0.0.0']
+    });
+
+    var hostname = resolver.resolveHost('some-key');
+    assert.ok(isIPv4(hostname));
+
+    resolver.close();
+    assert.end();
+})


### PR DESCRIPTION
This change allows us to give a seed list of IPs
    to the DNS resolver.

This means that if we send packets before
    the DNS is resolved or we are unable to
    resolve the DNS we will fall back to a static
    list of IPs.

Worst case scenario if DNS fails is that we hope
    the static IPs checked into the configuration
    in the application are actually statsd servers.

cc @sh1mmer @kriskowal @Matt-Esch
