### PR TITLE
[DNS recovery]: Bug fixes

### DIFF
--- a/lib/packet-queue.js
+++ b/lib/packet-queue.js
@@ -53,6 +53,7 @@ function PacketQueue(send, options) {
             self._sendPacket();
         }
     }, options.flush || 1000);
+    this._interval.unref();
 }
 
 PacketQueue.prototype.destroy = function() {


### PR DESCRIPTION
- we need to unref an interval otherwise its a breaking change. Previously statsd would not keep a process open.
- we need to reset writePos, we forgot to do so and it's a bug that causes us to flush empty buffers accidentally.

cc @jcorbin @sh1mmer @Matt-Esch @kriskowal
