### PR TITLE
[DNS Recovery]: Revert the cleanup timeout code.

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -1,4 +1,5 @@
 var setTimeout = require('timers').setTimeout;
+var clearTimeout = require('timers').clearTimeout;
 var Buffer = require('buffer').Buffer;
 var console = require('console');
 var dgram = require('dgram');
@@ -13,17 +14,43 @@ function ephemeralSocket(options) {
     self.options.host = self.options.host || 'localhost';
     self.options.port = self.options.port || 8125;
     self.options.debug = self.options.debug || false;
+
+    self.options.socket_timeout = self.options.socket_timeout || 1000;
     self.options.highWaterMark = self.options.highWaterMark || 100;
 
     // Set up re-usable socket
     self._socket = null; // Store the socket here
     self._queue = PacketQueue(onFlush, queueOptions);
+    self._socket_used = false; // Flag if it has been used
+    self._socket_timer = undefined; // Reference to check-timer
 
     // flush the packet queue
     function onFlush(buf) {
         self._writeToSocket(buf);
     }
 }
+
+/*
+ * Check if the socket has been used in the previous socket_timeout-interval.
+ * If it has, we leave it open and try again later. If it hasn't, close it.
+ */
+ephemeralSocket.prototype._socket_timeout = function () {
+    // Is it already closed? -- then stop here
+    if (!this._socket) {
+        return;
+    }
+
+    // Has been used? -- reset use-flag and wait some more
+    if (this._socket_used) {
+        this._socket_used = false;
+        this._socket_timer = setTimeout(this._socket_timeout.bind(this), this.options.socket_timeout);
+        return;
+    }
+
+    // Not used? -- close the socket
+    this.close();
+};
+
 
 /*
  * Close the socket, if in use and cancel the interval-check, if running.
@@ -33,6 +60,9 @@ ephemeralSocket.prototype.close = function () {
     if (!this._socket) {
         return;
     }
+
+    // Cancel the running timer
+    clearTimeout(this._socket_timer);
 
     // Wait a tick or two, so any remaining stats can be sent.
     var that = this;
@@ -52,6 +82,7 @@ ephemeralSocket.prototype.send = function (data) {
 ephemeralSocket.prototype._writeToSocket = function (data) {
     // Create socket if it isn't there
     allocSocket(this);
+    this._socket_used = true;
 
     // Create message
     var message = new Buffer(data);
@@ -77,6 +108,14 @@ function allocSocket(self) {
 
     self._socket = dgram.createSocket('udp4');
     self._socket.unref();
+
+    // Start timer, if we have a positive timeout
+    if (self.options.socket_timeout > 0) {
+        self._socket_timer = setTimeout(
+            self._socket_timeout.bind(self),
+            self.options.socket_timeout
+        );
+    }
 
     self._socket.once('error', onError);
 

--- a/test/socket.js
+++ b/test/socket.js
@@ -93,7 +93,7 @@ test('can send multiple packets', function t(assert) {
     });
 });
 
-test('socket will unref', function t(assert) {
+test('socket will close and timeout', function t(assert) {
     var server = UDPServer({ port: PORT }, function onBound() {
         var sock = new EphemeralSocket({
             host: 'localhost',
@@ -109,7 +109,12 @@ test('socket will unref', function t(assert) {
             var str = String(msg);
             assert.equal(str, 'hello');
 
-            sock._queue.destroy();
+            setTimeout(expectClosed, 50);
+        }
+
+        function expectClosed() {
+            assert.equal(sock._socket, undefined);
+
             server.close();
             assert.end();
         }


### PR DESCRIPTION
The UDP socket timeout is being relied on in production. Removing it
    is an unexceptable breaking change. Removing it increases the
    number of file descriptors used in production.

We will have to live with this code forever instead of enforcing
    a statsd client must be strictly closed policy.

cc @sh1mmer @kriskowal
