### PR TITLE
[DNS Recovery]: Get gauge() to write to the socket directly.

### DIFF
--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -37,7 +37,7 @@ StatsDClient.prototype.getChildClient = function (extraPrefix) {
  * gauge(name, value)
  */
 StatsDClient.prototype.gauge = function (name, value) {
-    this._ephemeralSocket.send(this.options.prefix + name + ":" + value + "|g");
+    this._ephemeralSocket._writeToSocket(this.options.prefix + name + ":" + value + "|g");
 };
 
 /*


### PR DESCRIPTION
For some reason gauge() breaks in production when using the
   packet queue. Dont know why.

We'll skip the packet queue for the gauge and see if that helps.

There is some evidence that gauge() + packet queue only breaks
    for statsite. There is a semantic difference in the
    implementation of gauge() in statsite and statsd.

cc @kriskowal @sh1mmer
