### PR TITLE
gaurd against double close

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -90,7 +90,9 @@ ephemeralSocket.prototype.close = function () {
     // Wait a tick or two, so any remaining stats can be sent.
     var that = this;
     setTimeout(function () {
-        that._socket.close();
+        if (that._socket) {
+            that._socket.close();
+        }
         that._socket = undefined;
     }, 10);
 };


### PR DESCRIPTION
We ran into a production bug with this. It looks like somehow the
    socket was double closed and two timers were allocated.

This just gaurds against the socket not existing instead of
    removing the race condition completely.

cc @jsu1212 @sh1mmer @Matt-Esch @kriskowal
