### PR TITLE
implement isDisabled for statsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ The `backoffSettings.minDelay` field defaults to `500` milliseconds
 The `backoffSettings.retries` field defaults to `10` retries
 The `backoffSettings.factor` field defaults to `2`.
 
+### `options.isDisabled`
+
+`isDisabled` is an optional predicate function. You can pass in
+    a predicate function that allows you to disabled the statsd
+    client at run time.
+
+When this predicate function returns `true` the `EphemeralSocket`
+    will stop writing to the statsd UDP server.
+
 ### Counting stuff
 
 Counters are supported, both as raw `.counter(metric, delta)` and with the

--- a/docs.jsig
+++ b/docs.jsig
@@ -15,6 +15,7 @@ uber-statsd-client : ({
     port?: Number,
     socket_timeout?: Number,
     highWaterMark?: Number,
+    isDisabled?: () => Boolean,
 
     packetQueue?: {
         block?: Number,

--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -21,6 +21,7 @@ function ephemeralSocket(options) {
     opts.socket_timeout = 'socket_timeout' in opts ?
         opts.socket_timeout : 1000;
     opts.highWaterMark = opts.highWaterMark || 100;
+    opts.isDisabled = opts.isDisabled || null;
 
     // Set up re-usable socket
     self._socket = null; // Store the socket here
@@ -105,6 +106,12 @@ ephemeralSocket.prototype.send = function (data) {
  * Send data.
  */
 ephemeralSocket.prototype._writeToSocket = function (data) {
+    if (this.options.isDisabled &&
+        this.options.isDisabled()
+    ) {
+        return;
+    }
+
     // Create socket if it isn't there
     allocSocket(this);
     this._socket_used = true;

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -13,6 +13,7 @@ function StatsDClient(options) {
 
     // Set defaults
     this.options.prefix = this.options.prefix || '';
+    this.options.isDisabled = this.options.isDisabled || null;
 
     // Prefix?
     if (this.options.prefix && this.options.prefix !== '') {


### PR DESCRIPTION
This allows you to pass a predicate function that
    disableds Statsd at runtime.

This will work cleanly if you have a runtime
    remote configuration service.

cc @sh1mmer
