### PR TITLE
Add null statsd.

### DIFF
--- a/docs.jsig
+++ b/docs.jsig
@@ -33,3 +33,5 @@ uber-statsd-client : ({
         }
     }
 }) => StatsDClient
+
+uber-statsd-client/null : (capacity?: Number) => StatsDClient

--- a/null.js
+++ b/null.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var RingBuffer = require('ringbufferjs');
+
+module.exports = NullStatsd;
+
+function NullStatsd(capacity) {
+    if (!(this instanceof NullStatsd)) {
+        return new NullStatsd(capacity);
+    }
+
+    this._buffer = new RingBuffer(capacity || 50);
+}
+
+function NullStatsdRecord(type, name, value, delta, time) {
+    this.type = type;
+    this.name = name;
+    this.value = value || null;
+    this.delta = delta || null;
+    this.time = time || null;
+}
+
+var proto = NullStatsd.prototype;
+
+proto._write = function _write(record) {
+    this._buffer.enq(record);
+};
+
+proto.gauge = function gauge(name, value) {
+    this._write(new NullStatsdRecord('g', name, value));
+};
+
+proto.counter = function counter(name, value) {
+    this._write(new NullStatsdRecord('c', name, null, value));
+};
+
+proto.increment = function increment(name, delta) {
+    this._write(new NullStatsdRecord(
+        'c',
+        name,
+        null,
+        delta || 1
+    ));
+};
+
+proto.decrement = function decrement(name, delta) {
+    this._write(new NullStatsdRecord(
+        'c',
+        name,
+        null,
+        (-1 * Math.abs(delta || 1))
+    ));
+};
+
+proto.timing = function timing(name, time) {
+    this._write(new NullStatsdRecord(
+        'ms',
+        name,
+        null,
+        null,
+        time
+    ));
+};
+
+proto.close = function close() {
+    for (var i = 0, len = this._buffer.size(); i < len; i++) {
+        this._buffer.deq();
+    }
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "back": "^0.1.5",
+    "ringbufferjs": "0.0.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -2,3 +2,4 @@ require('./socket.js');
 require('./packet-queue.js');
 require('./statsd-client.js');
 require('./resolve-dns.js');
+require('./null.js');

--- a/test/null.js
+++ b/test/null.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var test = require('tape');
+
+var NullStatsd = require('../null.js');
+
+test('null.gauge()', function t(assert) {
+    var c = NullStatsd();
+    c.gauge('some.key', 10);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'g',
+        name: 'some.key',
+        value: 10,
+        delta: null,
+        time: null
+    });
+
+    c.close();
+    assert.end();
+});
+
+test('null.counter()', function t(assert) {
+    var c = NullStatsd();
+    c.counter('some.key', 5);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key',
+        value: null,
+        delta: 5,
+        time: null
+    });
+
+    c.close();
+    assert.end();
+});
+
+test('null.increment()', function t(assert) {
+    var c = NullStatsd();
+
+    c.increment('some.key');
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key',
+        value: null,
+        delta: 1,
+        time: null
+    });
+
+    c._buffer.deq();
+    c.increment('some.key2', 3);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key2',
+        value: null,
+        delta: 3,
+        time: null
+    });
+
+    c.close();
+    assert.end();
+});
+
+test('null.decrement()', function t(assert) {
+    var c = NullStatsd();
+
+    c.decrement('some.key');
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key',
+        value: null,
+        delta: -1,
+        time: null
+    });
+    
+    c._buffer.deq();
+    c.decrement('some.key2', 3);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key2',
+        value: null,
+        delta: -3,
+        time: null
+    });
+
+    c._buffer.deq();
+    c.decrement('some.key3', -3);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'c',
+        name: 'some.key3',
+        value: null,
+        delta: -3,
+        time: null
+    });
+
+    c.close();
+    assert.end();
+});
+
+test('null.timing()', function t(assert) {
+    var c = NullStatsd();
+
+    c.timing('some.key', 500);
+
+    assert.deepEqual(c._buffer.peek(), {
+        type: 'ms',
+        name: 'some.key',
+        value: null,
+        delta: null,
+        time: 500
+    });
+
+    c.close();
+    assert.end();
+});


### PR DESCRIPTION
This adds a new `null` module that implements a dummy
statsd client for usage in tests & local.

reviewers: @iproctor @sh1mmer