### PR TITLE
add callback function for ephemeralSocket and statsd-client

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -105,7 +105,7 @@ ephemeralSocket.prototype.send = function (data) {
 /*
  * Send data.
  */
-ephemeralSocket.prototype._writeToSocket = function (data) {
+ephemeralSocket.prototype._writeToSocket = function (data, cb) {
     if (typeof this.options.isDisabled === 'function' &&
         this.options.isDisabled()
     ) {
@@ -132,8 +132,18 @@ ephemeralSocket.prototype._writeToSocket = function (data) {
             this._dnsResolver.resolveHost() :
             this.options.host;
 
-        this._socket.send(buf, 0, buf.length,
-            this.options.port, host);
+        if (cb) {
+            this._socket.send(buf, 0, buf.length,
+            this.options.port, host, cb);    
+        } else {
+            this._socket.send(buf, 0, buf.length,
+            this.options.port, host); 
+        }   
+        
+    } else {
+        if (cb) {
+            cb(new Error('could not send(). The dgram socket is full. Ignoring buffer'));
+        }
     }
     //TODO logger.warn() in else statement
 };

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -70,23 +70,6 @@ StatsDClient.prototype.increment = function (name, delta) {
     this.counter(name, Math.abs(delta || 1));
 };
 
-
-/*
- * counterBeforeTermination(name, delta)
- */
-StatsDClient.prototype.immediateCounter = function (name, delta, cb) {
-    name = this.options.prefix + name;
-    var message = new Messages.Counter(name, delta);
-    this._ephemeralSocket._writeToSocket(message.toString(), cb);
-}
-
-/*
- * incrementBeforeTermination(name, [delta=1])
- */
-StatsDClient.prototype.immediateIncrement = function (name, delta, cb) {
-    this.immediateCounter(name, Math.abs(delta || 1), cb);
-}
-
 /*
  * decrement(name, [delta=-1])
  */

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -70,6 +70,7 @@ StatsDClient.prototype.increment = function (name, delta) {
     this.counter(name, Math.abs(delta || 1));
 };
 
+
 /*
  * decrement(name, [delta=-1])
  */
@@ -87,6 +88,50 @@ StatsDClient.prototype.timing = function (name, time) {
     name = this.options.prefix + name;
     var message = new Messages.Timing(name, t);
     this._ephemeralSocket.send(message.toString());
+};
+
+/*
+ * immediateGauge(name, delta)
+ */
+ StatsDClient.prototype.immediateGauge = function (name, value, cb) {
+    name = this.options.prefix + name;
+    var message = new Messages.Gauge(name, value);
+    this._ephemeralSocket._writeToSocket(message.toString(), cb);
+ }
+
+/*
+ * immediateCounter(name, delta)
+ */
+StatsDClient.prototype.immediateCounter = function (name, delta, cb) {
+    name = this.options.prefix + name;
+    var message = new Messages.Counter(name, delta);
+    this._ephemeralSocket._writeToSocket(message.toString(), cb);
+}
+
+/*
+ * immediateIncrement(name, [delta=1])
+ */
+StatsDClient.prototype.immediateIncrement = function (name, delta, cb) {
+    this.immediateCounter(name, Math.abs(delta || 1), cb);
+}
+
+/*
+ * immediateDecrement(name, [delta=-1])
+ */
+StatsDClient.prototype.immediateDecrement = function (name, delta, cb) {
+    this.immediateCounter(name, -1 * Math.abs(delta || 1), cb);
+};
+
+/*
+ * immediateTimings(name, date-object | ms)
+ */
+StatsDClient.prototype.immediateTiming = function (name, time, cb) {
+    // Date-object or integer?
+    var t = time instanceof Date ? new Date() - time : time;
+
+    name = this.options.prefix + name;
+    var message = new Messages.Timing(name, t);
+    this._ephemeralSocket._writeToSocket(message.toString(), cb);
 };
 
 /*

--- a/test/statsd-client.js
+++ b/test/statsd-client.js
@@ -256,6 +256,125 @@ test('client.gauge()', function t(assert) {
     });
 });
 
+test('client.immediateCounter()', function t(assert) {
+    var server = UDPServer({ port: PORT }, function onBound() {
+        var sock = new StatsDClient({
+            host: 'localhost',
+            port: PORT
+        });
+
+        var messageSent = false;
+        server.once('message', onMessage);
+        sock.immediateCounter('hello', 10, function onCompleteSending() {
+            messageSent = true;
+        });
+
+        function onMessage(msg) {
+            var str = String(msg);
+            assert.equal(str, 'hello:10|c');
+            assert.equal(messageSent, true);
+            sock.close();
+            server.close();
+            assert.end();
+        }
+    });
+});
+
+test('client.immediateIncrement()', function t(assert) {
+    var server = UDPServer({ port: PORT }, function onBound() {
+        var sock = new StatsDClient({
+            host: 'localhost',
+            port: PORT
+        });
+
+        var messageSent = false;
+        server.once('message', onMessage);
+        sock.immediateIncrement('hello', null, function onCompleteSending() {
+            messageSent = true;
+        });
+
+        function onMessage(msg) {
+            var str = String(msg);
+            assert.equal(str, 'hello:1|c');
+            assert.equal(messageSent, true);
+            sock.close();
+            server.close();
+            assert.end();
+        }
+    });
+});
+
+test('client.immediateDecrement()', function t(assert) {
+    var server = UDPServer({ port: PORT }, function onBound() {
+        var sock = new StatsDClient({
+            host: 'localhost',
+            port: PORT
+        });
+
+        var messageSent = false;
+        server.once('message', onMessage);
+        sock.immediateDecrement('hello', null, function onCompleteSending() {
+            messageSent = true;
+        });
+
+        function onMessage(msg) {
+            var str = String(msg);
+            assert.equal(str, 'hello:-1|c');
+            assert.equal(messageSent, true);
+            sock.close();
+            server.close();
+            assert.end();
+        }
+    });
+});
+
+test('client.immediateGauge()', function t(assert) {
+    var server = UDPServer({ port: PORT }, function onBound() {
+        var sock = new StatsDClient({
+            host: 'localhost',
+            port: PORT
+        });
+
+        var messageSent = false;
+        server.once('message', onMessage);
+        sock.immediateGauge('hello', 10, function onCompleteSending() {
+            messageSent = true;
+        });
+
+        function onMessage(msg) {
+            var str = String(msg);
+            assert.equal(str, 'hello:10|g');
+            assert.equal(messageSent, true);
+
+            sock.close();
+            server.close();
+            assert.end();
+        }
+    });
+})
+
+test('client.immediateTiming() with Date', function t(assert) {
+    var server = UDPServer({ port: PORT }, function onBound() {
+        var client = new StatsDClient({
+            prefix: 'bar'
+        });
+
+        var messageSent = false;
+        client.immediateTiming('foo', new Date(), function onCompleteSending() {
+            messageSent = true;
+        });
+        server.once('message', function (msg) {
+            assert.equal(msg.toString(), 'bar.foo:0|ms');
+            assert.equal(messageSent, true);
+
+            server.close();
+            client.close();
+            assert.end();
+        });
+    });
+})
+
+
 test('can write with DNS resolver', function t(assert) {
     var server = UDPServer({ port: PORT }, function onBound() {
         var client = new StatsDClient({


### PR DESCRIPTION
In order to ensure statsd before server crashes, we can take advantage of socket.send of udp socket. The callback function is called when the messages was sent. I made such changes:
Add a callback function field in _writeToSocket in EphemeralSocket.js
Add two function to increment immediately in statsd-client.js
Thanks.