### PR TITLE
if delta is precisely 0, just return

### DIFF
--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -67,6 +67,9 @@ StatsDClient.prototype.counter = function (name, delta) {
  * increment(name, [delta=1])
  */
 StatsDClient.prototype.increment = function (name, delta) {
+    if (delta === 0) {
+        return;
+    }
     this.counter(name, Math.abs(delta || 1));
 };
 
@@ -74,6 +77,9 @@ StatsDClient.prototype.increment = function (name, delta) {
  * decrement(name, [delta=-1])
  */
 StatsDClient.prototype.decrement = function (name, delta) {
+    if (delta === 0) {
+        return;
+    }
     this.counter(name, -1 * Math.abs(delta || 1));
 };
 
@@ -111,6 +117,9 @@ StatsDClient.prototype.immediateCounter = function (name, delta, cb) {
  * immediateIncrement(name, [delta=1])
  */
 StatsDClient.prototype.immediateIncrement = function (name, delta, cb) {
+    if (delta === 0) {
+        return;
+    }
     this.immediateCounter(name, Math.abs(delta || 1), cb);
 }
 
@@ -118,6 +127,9 @@ StatsDClient.prototype.immediateIncrement = function (name, delta, cb) {
  * immediateDecrement(name, [delta=-1])
  */
 StatsDClient.prototype.immediateDecrement = function (name, delta, cb) {
+    if (delta === 0) {
+        return;
+    }
     this.immediateCounter(name, -1 * Math.abs(delta || 1), cb);
 };
 


### PR DESCRIPTION
If delta is precisely 0 in an increment or decrement, just return. Fixes a bug where increment(stat, 0) would increment it by 1.

@Raynos 