### PR TITLE
Make time-based flushing and dns resolver work after socket timeout.

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -67,26 +67,33 @@ ephemeralSocket.prototype._socket_timeout = function () {
 
     // Not used? -- close the socket
     //TODO logger.warn() about closing socket on timeout
-    this.close();
+    this._close_socket();
 };
 
-
 /*
- * Close the socket, if in use and cancel the interval-check, if running.
+ * Close the socket, stop time-based queue flushing and close DNS resolution
  */
 ephemeralSocket.prototype.close = function () {
     this._queue.destroy();
     //TODO logger.warn() about double close()
+
+    this._close_socket();
+
+    if (this._dnsResolver) {
+        this._dnsResolver.close();
+    }
+};
+
+/*
+ * Tear-down the socket since it isn't being used
+ */
+ephemeralSocket.prototype._close_socket = function () {
     if (!this._socket) {
         return;
     }
 
     // Cancel the running timer
     clearTimeout(this._socket_timer);
-
-    if (this._dnsResolver) {
-        this._dnsResolver.close();
-    }
 
     // Wait a tick or two, so any remaining stats can be sent.
     var that = this;


### PR DESCRIPTION
Closes uber/node-statsd-client#31.