### PR TITLE
Make sure that getChildClient() is cheap

### DIFF
--- a/benchmarks/child-client.js
+++ b/benchmarks/child-client.js
@@ -1,0 +1,24 @@
+var SDC = require('../lib/statsd-client.js');
+
+var client = new SDC({
+    prefix: 'bar'
+});
+
+
+var ITERATIONS = 10 * 1000 * 1000;
+
+var start = Date.now();
+var children = new Array(10);
+
+for (var i = 0; i < ITERATIONS; i++) {
+    var index = ITERATIONS % 10;
+
+    children[index] = client.getChildClient('foo');
+}
+
+var end = Date.now();
+console.log('time: ', end - start);
+
+client.close();
+
+

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -41,7 +41,9 @@ function StatsDClient(options) {
 StatsDClient.prototype.getChildClient = function (extraPrefix) {
     return new StatsDClient({
         prefix: this.options.prefix + extraPrefix,
-        _ephemeralSocket: this._ephemeralSocket
+        _ephemeralSocket: this._ephemeralSocket,
+        dnsResolver: this.options.dnsResolver,
+        isDisabled: this.options.isDisabled
     });
 };
 

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -27,23 +27,21 @@ function enforceDotOnPrefix(prefix) {
  * be set.
  */
 function createStatsDClient(options) {
-    var stableOptions = new StatsdClientOptions(
-        (options && options.prefix) ? options.prefix : '',
-        (options && options.isDisabled) ? options.isDisabled : null,
-        (options && options.dnsResolver) ? options.dnsResolver : null
-    );
+    options = options || {};
+    options.prefix = options.prefix || '';
+    options.isDisabled = options.isDisabled || null;
 
     var _ephemeralSocket = (options && options._ephemeralSocket) ||
         new EphemeralSocket(options);
 
-    if (stableOptions.dnsResolver &&
+    if (options.dnsResolver &&
         _ephemeralSocket.resolveDNS &&
         !_ephemeralSocket._dnsResolver
     ) {
-        _ephemeralSocket.resolveDNS(stableOptions.dnsResolver);
+        _ephemeralSocket.resolveDNS(options.dnsResolver);
     }
 
-    return new StatsDClient(stableOptions, _ephemeralSocket);
+    return new StatsDClient(options, _ephemeralSocket);
 }
 
 /*

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -1,6 +1,24 @@
 var EphemeralSocket = require('./EphemeralSocket');
 var Messages = require('./messages.js');
 
+function StatsdClientOptions(prefix, isDisabled, dnsResolver) {
+    this.prefix = prefix;
+    this.isDisabled = isDisabled;
+    this.dnsResolver = dnsResolver;
+}
+
+function StatsDClient(options, _ephemeralSocket) {
+    this.options = options;
+    this._ephemeralSocket = _ephemeralSocket;
+
+    if (this.options.prefix && this.options.prefix !== '') {
+        this.options.prefix = enforceDotOnPrefix(this.options.prefix);
+    }
+}
+
+function enforceDotOnPrefix(prefix) {
+    return prefix[prefix.length - 1] === '.' ? prefix : prefix + '.';
+}
 
 /*
  * Set up the statsd-client.
@@ -8,44 +26,38 @@ var Messages = require('./messages.js');
  * Requires the `hostname`. Options currently allows for `port` and `debug` to
  * be set.
  */
-function StatsDClient(options) {
-    this.options = options || {};
+function createStatsDClient(options) {
+    var stableOptions = new StatsdClientOptions(
+        (options && options.prefix) ? options.prefix : '',
+        (options && options.isDisabled) ? options.isDisabled : null,
+        (options && options.dnsResolver) ? options.dnsResolver : null
+    );
 
-    // Set defaults
-    this.options.prefix = this.options.prefix || '';
-    this.options.isDisabled = this.options.isDisabled || null;
-
-    // Prefix?
-    if (this.options.prefix && this.options.prefix !== '') {
-        // Add trailing dot if it's missing
-        var p = this.options.prefix;
-        this.options.prefix = p[p.length - 1] === '.' ?
-            p : p + '.';
-    }
-
-    // Ephemeral socket
-    this._ephemeralSocket = this.options._ephemeralSocket ||
+    var _ephemeralSocket = (options && options._ephemeralSocket) ||
         new EphemeralSocket(options);
 
-    if (this.options.dnsResolver &&
-        this._ephemeralSocket.resolveDNS &&
-        !this._ephemeralSocket._dnsResolver
+    if (stableOptions.dnsResolver &&
+        _ephemeralSocket.resolveDNS &&
+        !_ephemeralSocket._dnsResolver
     ) {
-        this._ephemeralSocket.resolveDNS(
-            this.options.dnsResolver);
+        _ephemeralSocket.resolveDNS(stableOptions.dnsResolver);
     }
+
+    return new StatsDClient(stableOptions, _ephemeralSocket);
 }
 
 /*
  * Get a "child" client with a sub-prefix.
  */
 StatsDClient.prototype.getChildClient = function (extraPrefix) {
-    return new StatsDClient({
-        prefix: this.options.prefix + extraPrefix,
-        _ephemeralSocket: this._ephemeralSocket,
-        dnsResolver: this.options.dnsResolver,
-        isDisabled: this.options.isDisabled
-    });
+    return new StatsDClient(
+        new StatsdClientOptions(
+            this.options.prefix + extraPrefix,
+            this.options.isDisabled,
+            this.options.dnsResolver
+        ),
+        this._ephemeralSocket
+    );
 };
 
 /*
@@ -155,4 +167,4 @@ StatsDClient.prototype.close = function () {
     this._ephemeralSocket.close();
 };
 
-module.exports = StatsDClient;
+module.exports = createStatsDClient;

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -28,7 +28,8 @@ function StatsDClient(options) {
         new EphemeralSocket(options);
 
     if (this.options.dnsResolver &&
-        this._ephemeralSocket.resolveDNS
+        this._ephemeralSocket.resolveDNS &&
+        !this._ephemeralSocket._dnsResolver
     ) {
         this._ephemeralSocket.resolveDNS(
             this.options.dnsResolver);


### PR DESCRIPTION
This makes two changes: first fix any missing options not
passed to child.

Secondly ensure that all children share the same dnsResolver.

r: @Matt-Esch @syyang